### PR TITLE
Fixed #7

### DIFF
--- a/ebmlite/encoding.py
+++ b/ebmlite/encoding.py
@@ -136,8 +136,17 @@ def encodeInt(val, length=None):
         @return: binary representation of val as a signed integer, left-padded with 00
         @raise ValueError: raised if val is longer than length.
     """
-    pad = b"\xff" if val < 0 else b"\x00"
-    packed = _struct_int64.pack(val).lstrip(pad)
+    if val == 0:
+        packed = ''
+    elif val > 0:
+        packed = _struct_int64.pack(val).lstrip('\x00')
+        if ord(packed[0]) & 0b10000000:
+            packed = '\x00' + packed
+    else:
+        packed = _struct_int64.pack(val).lstrip('\xff')
+        if not ord(packed[0]) & 0b10000000:
+            packed = '\xff' + packed
+
     if length is None:
         return packed
     if len(packed) > length:

--- a/ebmlite/encoding.py
+++ b/ebmlite/encoding.py
@@ -44,8 +44,9 @@ STRING_CHARACTERS = (b"?"*32 + bytearray(range(32,127))).ljust(256, b'?')
 
 def getLength(val):
     """ Calculate the encoded length of a value.
-        @param val: A value to be encoded, generally either an ID or a size for an EBML element
-        @return The minimum length, in bytes, that can be used to represent (val)
+        @param val: A value to be encoded, generally either an ID or a size for
+            an EBML element
+        @return The minimum length, in bytes, that can be used to represent val
     """
     # Brute force it. Ugly but faster than calculating it.
     if val <= 126:
@@ -73,8 +74,9 @@ def encodeSize(val, length=None):
             will be returned (1 or `length` bytes, all bits 1).
         @keyword length: An explicit length for the encoded size. If `None`,
             the size will be encoded at the minimum length required.
-        @return: an encoded size for an EBML element
-        @raise ValueError: raised if the length is invalid, or the length cannot be encoded
+        @return: an encoded size for an EBML element.
+        @raise ValueError: raised if the length is invalid, or the length cannot
+            be encoded.
     """
     if val is None:
         # 'unknown' size: all bits 1.
@@ -99,7 +101,9 @@ def encodeId(eid, length=None):
         @param eid: The EBML ID to encode.
         @keyword length: An explicit length for the encoded data. A `ValueError`
             will be raised if the length is too short to encode the value.
-        @return: The encoded ID eid
+        @return: The binary representation of ID, left-padded with ``0x00`` if
+            `length` is not `None`.
+        @return: The encoded version of the ID.
         @raise ValueError: raised if length is less than one or more than 4.
     """
     if length is not None:
@@ -115,7 +119,8 @@ def encodeUInt(val, length=None):
         @param val: The unsigned integer value to encode.
         @keyword length: An explicit length for the encoded data. A `ValueError`
             will be raised if the length is too short to encode the value.
-        @return: binary representation of val as an unsigned integer, left-padded with 00
+        @return: The binary representation of val as an unsigned integer,
+            left-padded with ``0x00`` if `length` is not `None`.
         @raise ValueError: raised if val is longer than length.
     """
     packed = _struct_uint64.pack(val).lstrip(b'\x00')
@@ -133,19 +138,24 @@ def encodeInt(val, length=None):
         @param val: The signed integer value to encode.
         @keyword length: An explicit length for the encoded data. A `ValueError`
             will be raised if the length is too short to encode the value.
-        @return: binary representation of val as a signed integer, left-padded with 00
+        @return: The binary representation of val as a signed integer,
+            left-padded with either ```0x00`` (for positive values) or ``0xFF``
+            (for negative) if `length` is not `None`.
         @raise ValueError: raised if val is longer than length.
     """
     if val == 0:
         packed = ''
+        pad = '\x00'
     elif val > 0:
-        packed = _struct_int64.pack(val).lstrip('\x00')
+        pad = '\x00'
+        packed = _struct_int64.pack(val).lstrip(pad)
         if ord(packed[0]) & 0b10000000:
-            packed = '\x00' + packed
+            packed = pad + packed
     else:
-        packed = _struct_int64.pack(val).lstrip('\xff')
+        pad = '\xff'
+        packed = _struct_int64.pack(val).lstrip(pad)
         if not ord(packed[0]) & 0b10000000:
-            packed = '\xff' + packed
+            packed = pad + packed
 
     if length is None:
         return packed
@@ -161,7 +171,8 @@ def encodeFloat(val, length=None):
         @param val: The floating point value to encode.
         @keyword length: An explicit length for the encoded data. Must be
             `None`, 0, 4, or 8; otherwise, a `ValueError` will be raised.
-        @return: binary representation of val as a float, left-padded with 00
+        @return: The binary representation of val as a float, left-padded with
+            ``0x00`` if `length` is not `None`.
         @raise ValueError: raised if val not length 0, 4, or 8
     """
     if length is None:
@@ -188,7 +199,8 @@ def encodeBinary(val, length=None):
         @keyword length: An explicit length for the encoded data. A
             `ValueError` will be raised if `length` is shorter than the
             actual length of the binary data.
-        @return: binary representation of value as binary data, left-padded with 00
+        @return: The binary representation of value as binary data, left-padded
+            with ``0x00`` if `length` is not `None`.
         @raise ValueError: raised if val is longer than length.
     """
     if isinstance(val, unicode):
@@ -209,9 +221,12 @@ def encodeString(val, length=None):
     """ Encode an ASCII string.
 
         @param val: The string (or bytearray) to encode.
+        @keyword length: An explicit length for the encoded data. Longer
+            strings will be truncated.
         @keyword length: An explicit length for the encoded data. The result
             will be truncated if the length is less than that of the original.
-        @return: binary representation of val as a string, truncated to length
+        @return: The binary representation of val as a string, truncated or
+            left-padded with ``0x00`` if `length` is not `None`.
     """
     if isinstance(val, unicode):
         val = val.encode('ascii', 'replace')
@@ -228,7 +243,8 @@ def encodeUnicode(val, length=None):
         @param val: The Unicode string to encode.
         @keyword length: An explicit length for the encoded data. The result
             will be truncated if the length is less than that of the original.
-        @return: binary representation of val as a unicode string, truncated to length
+        @return: The binary representation of val as a string, truncated or
+            left-padded with ``0x00`` if `length` is not `None`.
     """
     val = val.encode('utf_8')
 
@@ -245,7 +261,7 @@ def encodeDate(val, length=None):
         @param val: The `datetime.datetime` object value to encode.
         @keyword length: An explicit length for the encoded data. Must be
             `None` or 8; otherwise, a `ValueError` will be raised.
-        @return: binary representation of val as an 8-byte dateTime.
+        @return: The binary representation of val as an 8-byte dateTime.
         @raise ValueError: raised if the length of the input is not 8 bytes.
     """
     if length is None:


### PR DESCRIPTION
There's probably a more efficient way to check the MSB of an arbitrarily-long signed integer, but this seems to do the trick.