### PR TITLE
updated to avoid deprecated methods in xml package

### DIFF
--- a/ebmlite/core.py
+++ b/ebmlite/core.py
@@ -1113,7 +1113,7 @@ class Schema(object):
         """ Recursively crawl a schema XML definition file.
         """
         if el.tag == "Schema":
-            for chEl in el.getchildren():
+            for chEl in el:
                 self._parseSchema(chEl, self)
             return
 
@@ -1139,7 +1139,7 @@ class Schema(object):
         cls = self.addElement(eid, ename, baseClass, attribs, parent, docs)
 
         if baseClass is MasterElement:
-            for chEl in el.getchildren():
+            for chEl in el:
                 self._parseSchema(chEl, cls)
 
 


### PR DESCRIPTION
Using `__iter__` instead prevents `DeprecationWarnings` from being raised, which reduces clutter in (py)test reports.