### PR TITLE
Expanding test cases

### DIFF
--- a/ebmlite/encoding.py
+++ b/ebmlite/encoding.py
@@ -123,13 +123,15 @@ def encodeUInt(val, length=None):
             left-padded with ``0x00`` if `length` is not `None`.
         @raise ValueError: raised if val is longer than length.
     """
-    packed = _struct_uint64.pack(val).lstrip(b'\x00')
+    pad = '\x00'
+    packed = _struct_uint64.pack(val).lstrip(pad)
+
     if length is None:
         return packed
     if len(packed) > length:
         raise ValueError("Encoded length (%d) greater than specified length "
                          "(%d)" % (len(packed), length))
-    return packed.rjust(length, b'\x00')
+    return packed.rjust(length, pad)
 
 
 def encodeInt(val, length=None):
@@ -151,14 +153,9 @@ def encodeInt(val, length=None):
         packed = _struct_int64.pack(val).lstrip(pad)
         if ord(packed[0]) & 0b10000000:
             packed = pad + packed
-    elif val == -1:
-        # Special case for -1 to avoid stripping data with padding below
-        # 2's complement of -1 is 0xFF, shortened to one byte is this value:
-        packed = '\xff'
-        pad = '\xff'
     else:
         pad = '\xff'
-        packed = _struct_int64.pack(val).lstrip(pad)
+        packed = _struct_int64.pack(val).lstrip(pad) or pad
         if not ord(packed[0]) & 0b10000000:
             packed = pad + packed
 

--- a/ebmlite/encoding.py
+++ b/ebmlite/encoding.py
@@ -123,7 +123,7 @@ def encodeUInt(val, length=None):
             left-padded with ``0x00`` if `length` is not `None`.
         @raise ValueError: raised if val is longer than length.
     """
-    pad = '\x00'
+    pad = b'\x00'
     packed = _struct_uint64.pack(val).lstrip(pad)
 
     if length is None:
@@ -146,15 +146,15 @@ def encodeInt(val, length=None):
         @raise ValueError: raised if val is longer than length.
     """
     if val == 0:
-        packed = ''
-        pad = '\x00'
+        packed = b''
+        pad = b'\x00'
     elif val > 0:
-        pad = '\x00'
+        pad = b'\x00'
         packed = _struct_int64.pack(val).lstrip(pad)
         if ord(packed[0]) & 0b10000000:
             packed = pad + packed
     else:
-        pad = '\xff'
+        pad = b'\xff'
         packed = _struct_int64.pack(val).lstrip(pad) or pad
         if not ord(packed[0]) & 0b10000000:
             packed = pad + packed

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -21,7 +21,7 @@ class testDecoding(unittest.TestCase):
             byte of the size.
         """
         
-        for i in range(1, 255):
+        for i in range(1, 256):
             self.assertEqual(decodeIntLength(i),
                              (ceil(8 - log(i, 2)), i - 2**floor(log(i, 2)) ))
             
@@ -32,7 +32,7 @@ class testDecoding(unittest.TestCase):
             the ID.
         """
         
-        for i in range(16, 255):
+        for i in range(16, 256):
             self.assertEqual((ceil(8-log(i, 2)), i), decodeIDLength(i))
 
 

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -14,22 +14,22 @@ class testEncoding(unittest.TestCase):
         """ Test converting unsigned ints to bytes. """
         
         # chars
-        for i in range(1, 255):
+        for i in range(0, 256):
             self.assertEqual(encodeUInt(i), chr(i),
                              'Character %X not encoded properly' % i)
             
         # uint16
-        for i in range(1, 255):
+        for i in range(0, 256):
             self.assertEqual(encodeUInt((i<<8) + 0x41), chr(i) + 'A',
                              'Character %X not encoded properly' % i)
             
         # uint32
-        for i in range(1, 255):
+        for i in range(0, 256):
             self.assertEqual(encodeUInt((i<<24) + 0x414141), chr(i) + 'AAA',
                              "Character %X not encoded properly" % i)
             
         # uint64
-        for i in range(1, 255):
+        for i in range(0, 256):
             self.assertEqual(encodeUInt((i<<56) + 0x41414141414141), chr(i) + 'AAAAAAA',
                              'Character %X not encoded properly' % i)
             
@@ -39,22 +39,22 @@ class testEncoding(unittest.TestCase):
         """ Test converting signed integers into bytes. """
         
         # chars
-        for i in range(-127, 0):
+        for i in range(-128, 0):
             self.assertEqual(encodeInt(i), chr(255 + i + 1),
                              'Character %X  not encoded properly' % (255 + i + 1))
             
         # int16
-        for i in range(-127, 0):
+        for i in range(-128, 0):
             self.assertEqual(encodeInt((i<<8) + 0x41), chr(255 + i + 1) + 'A',
                              'Character %X  not encoded properly' % (255 + i + 1))
             
         # int32
-        for i in range(-127, 0):
+        for i in range(-128, 0):
             self.assertEqual(encodeInt((i<<24) + 0x414141), chr(255 + i + 1) + 'AAA',
                              'Character %X  not encoded properly' % (255 + i + 1))
             
         # int64
-        for i in range(-127, 0):
+        for i in range(-128, 0):
             self.assertEqual(encodeInt((i<<56) + 0x41414141414141), chr(255 + i + 1) + 'AAAAAAA',
                              'Character %X  not encoded properly' % (255 + i + 1))
         

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -39,22 +39,22 @@ class testEncoding(unittest.TestCase):
         """ Test converting signed integers into bytes. """
         
         # chars
-        for i in range(-128, 0):
+        for i in range(-128, 128):
             self.assertEqual(encodeInt(i), chr(255 + i + 1),
                              'Character %X  not encoded properly' % (255 + i + 1))
             
         # int16
-        for i in range(-128, 0):
+        for i in range(-128, 128):
             self.assertEqual(encodeInt((i<<8) + 0x41), chr(255 + i + 1) + 'A',
                              'Character %X  not encoded properly' % (255 + i + 1))
             
         # int32
-        for i in range(-128, 0):
+        for i in range(-128, 128):
             self.assertEqual(encodeInt((i<<24) + 0x414141), chr(255 + i + 1) + 'AAA',
                              'Character %X  not encoded properly' % (255 + i + 1))
             
         # int64
-        for i in range(-128, 0):
+        for i in range(-128, 128):
             self.assertEqual(encodeInt((i<<56) + 0x41414141414141), chr(255 + i + 1) + 'AAAAAAA',
                              'Character %X  not encoded properly' % (255 + i + 1))
         

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -12,54 +12,87 @@ class testEncoding(unittest.TestCase):
     
     def testUInt(self):
         """ Test converting unsigned ints to bytes. """
-        
-        # chars
+
+        # General cases
+        #   chars
         for i in range(0, 256):
-            self.assertEqual(encodeUInt(i), chr(i),
+            self.assertEqual(encodeUInt(i, length=1), chr(i),
                              'Character %X not encoded properly' % i)
             
-        # uint16
+        #   uint16
         for i in range(0, 256):
-            self.assertEqual(encodeUInt((i<<8) + 0x41), chr(i) + 'A',
+            self.assertEqual(encodeUInt((i<<8) + 0x41, length=2), chr(i) + 'A',
                              'Character %X not encoded properly' % i)
             
-        # uint32
+        #   uint32
         for i in range(0, 256):
-            self.assertEqual(encodeUInt((i<<24) + 0x414141), chr(i) + 'AAA',
+            self.assertEqual(encodeUInt((i<<24) + 0x414141, length=4), chr(i) + 'AAA',
                              "Character %X not encoded properly" % i)
             
-        # uint64
+        #   uint64
         for i in range(0, 256):
-            self.assertEqual(encodeUInt((i<<56) + 0x41414141414141), chr(i) + 'AAAAAAA',
+            self.assertEqual(encodeUInt((i<<56) + 0x41414141414141, length=8), chr(i) + 'AAAAAAA',
                              'Character %X not encoded properly' % i)
-            
-    
-    
+
+        # Length paramater behavior
+        #   unspecified length calls should truncate to smallest length possible
+        self.assertEqual(encodeUInt(0x123), '\x01\x23')
+        #   which for zero is an empty string
+        self.assertEqual(encodeUInt(0), '')
+        
+        #   specified length should pad to given length for all values
+        self.assertEqual(encodeUInt(0x123, length=3), '\x00\x01\x23')
+        #   and specifying a length that's too small should result in a ValueError
+        with self.assertRaises(ValueError):
+            encodeUInt(0x123, length=1)
+
+
+
     def testInt(self):
         """ Test converting signed integers into bytes. """
+
+        # General cases
+        #   chars
+        for i in range(-128, 128):
+            self.assertEqual(encodeInt(i, length=1), chr(i % 256),
+                             'Character %X  not encoded properly' % (i % 256))
+            
+        #   int16
+        for i in range(-128, 128):
+            self.assertEqual(encodeInt((i<<8) + 0x41, length=2), chr(i % 256) + 'A',
+                             'Character %X  not encoded properly' % (i % 256))
+            
+        #   int32
+        for i in range(-128, 128):
+            self.assertEqual(encodeInt((i<<24) + 0x414141, length=4), chr(i % 256) + 'AAA',
+                             'Character %X  not encoded properly' % (i % 256))
+            
+        #   int64
+        for i in range(-128, 128):
+            self.assertEqual(encodeInt((i<<56) + 0x41414141414141, length=8), chr(i % 256) + 'AAAAAAA',
+                             'Character %X  not encoded properly' % (i % 256))
+
+        # Length paramater behavior
+        #   unspecified length calls should truncate to smallest length possible
+        self.assertEqual(encodeInt(0x123), '\x01\x23')
+        self.assertEqual(encodeInt(-0x123), '\xfe\xdd')
+        #   which for zero is an empty string
+        self.assertEqual(encodeInt(0), '')
+        self.assertEqual(encodeInt(-1), '\xff')
         
-        # chars
-        for i in range(-128, 128):
-            self.assertEqual(encodeInt(i), chr(i % 256),
-                             'Character %X  not encoded properly' % (i % 256))
-            
-        # int16
-        for i in range(-128, 128):
-            self.assertEqual(encodeInt((i<<8) + 0x41), chr(i % 256) + 'A',
-                             'Character %X  not encoded properly' % (i % 256))
-            
-        # int32
-        for i in range(-128, 128):
-            self.assertEqual(encodeInt((i<<24) + 0x414141), chr(i % 256) + 'AAA',
-                             'Character %X  not encoded properly' % (i % 256))
-            
-        # int64
-        for i in range(-128, 128):
-            self.assertEqual(encodeInt((i<<56) + 0x41414141414141), chr(i % 256) + 'AAAAAAA',
-                             'Character %X  not encoded properly' % (i % 256))
-        
-           
-     
+        #   specified length should pad to given length for all values
+        self.assertEqual(encodeInt(0x123, length=3), '\x00\x01\x23')
+        self.assertEqual(encodeInt(-0x123, length=3), '\xff\xfe\xdd')
+        #   and specifying a length that's too small should result in a ValueError
+        with self.assertRaises(ValueError):
+            encodeInt(0x123, length=1)
+        with self.assertRaises(ValueError):
+            encodeInt(-0x123, length=1)
+        with self.assertRaises(ValueError):
+            encodeInt(-1, length=0)
+
+
+
     def testFloat(self):
         """ Test converting floats into bytes. """
         

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -40,23 +40,23 @@ class testEncoding(unittest.TestCase):
         
         # chars
         for i in range(-128, 128):
-            self.assertEqual(encodeInt(i), chr(255 + i + 1),
-                             'Character %X  not encoded properly' % (255 + i + 1))
+            self.assertEqual(encodeInt(i), chr(i % 256),
+                             'Character %X  not encoded properly' % (i % 256))
             
         # int16
         for i in range(-128, 128):
-            self.assertEqual(encodeInt((i<<8) + 0x41), chr(255 + i + 1) + 'A',
-                             'Character %X  not encoded properly' % (255 + i + 1))
+            self.assertEqual(encodeInt((i<<8) + 0x41), chr(i % 256) + 'A',
+                             'Character %X  not encoded properly' % (i % 256))
             
         # int32
         for i in range(-128, 128):
-            self.assertEqual(encodeInt((i<<24) + 0x414141), chr(255 + i + 1) + 'AAA',
-                             'Character %X  not encoded properly' % (255 + i + 1))
+            self.assertEqual(encodeInt((i<<24) + 0x414141), chr(i % 256) + 'AAA',
+                             'Character %X  not encoded properly' % (i % 256))
             
         # int64
         for i in range(-128, 128):
-            self.assertEqual(encodeInt((i<<56) + 0x41414141414141), chr(255 + i + 1) + 'AAAAAAA',
-                             'Character %X  not encoded properly' % (255 + i + 1))
+            self.assertEqual(encodeInt((i<<56) + 0x41414141414141), chr(i % 256) + 'AAAAAAA',
+                             'Character %X  not encoded properly' % (i % 256))
         
            
      


### PR DESCRIPTION
The goal for this pull request is to expand tests for (u)int-encoding, to avoid any hidden bugs like, e.g., issue #17.

I have included herein some changes that expand test case ranges to include additional values (like 0 & 255 for uint8 values, and 0-127 for int8 values). However, some of the included test cases currently fail (which is a good sign that this is a task worth performing). From my conversation w/ @CFlaniganMide, he has found the source of the problem for some (all?) of these cases, and I will leave it up to him to make the appropriate fixes (unless I am informed otherwise).