### PR TITLE
Add static code checking to Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 before_install:
   - python --version
 install: pip install .[test]
-script: python -m pytest --cov=ebmlite
+script: python -m pytest --cov=ebmlite --flake8
 after_success:
   - codecov
 

--- a/ebmlite/core.py
+++ b/ebmlite/core.py
@@ -54,7 +54,7 @@ from xml.etree import ElementTree as ET
 
 from .decoding import readElementID, readElementSize
 from .decoding import readFloat, readInt, readUInt, readDate
-from .decoding import readString, readUnicode
+from .decoding import readUnicode
 from . import encoding
 from . import schemata
 

--- a/ebmlite/threaded_file.py
+++ b/ebmlite/threaded_file.py
@@ -13,10 +13,11 @@ __credits__ = "David Randall Stokes, Connor Flanigan, Becker Awqatty, Derek Witt
 
 __all__ = ['ThreadAwareFile']
 
+import io
 import platform
 from threading import currentThread, Event
 
-class ThreadAwareFile(file):
+class ThreadAwareFile(io.IOBase):
     """ A 'replacement' for a standard read-only file stream that supports
         simultaneous access by multiple threads without (explicit) blocking.
         Each thread actually gets its own stream, so it can perform its own
@@ -91,7 +92,7 @@ class ThreadAwareFile(file):
         """
         if isinstance(fileStream, cls):
             return fileStream
-        elif not isinstance(fileStream, file):
+        elif not isinstance(fileStream, io.IOBase):
             raise TypeError("Not a file: %r" % fileStream)
 
         f = cls(fileStream.name, fileStream.mode, _new=False)
@@ -107,7 +108,7 @@ class ThreadAwareFile(file):
         ident = currentThread().ident
         if ident not in self.threads:
             # First access from this thread. Open the file.
-            fp = file(*self.initArgs, **self.initKwargs)
+            fp = io.IOBase(*self.initArgs, **self.initKwargs)
             self.threads[ident] = fp
             return fp
         return self.threads[ident]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+select = F
+exclude = tests/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [flake8]
 select = F
+per-file-ignores = __init__.py:F401,F403
 exclude = tests/*

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ TEST_REQUIRES = [
     'pytest>=4.6',
     'codecov',
     'pytest-cov',
+    'pytest-flake8',
     ]
 
 setuptools.setup(

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -5,7 +5,6 @@ Created on Aug 14, 2017
 """
 
 import unittest
-import pytest
 from xml.dom.minidom import parseString
 from xml.etree import ElementTree as ET
 


### PR DESCRIPTION
This PR adds flake8 to the Travis CI tests, in order to flag *purely* logical errors like unused imports. (Non-logical errors are disabled; see fc6aed3)