### PR TITLE
Added heater peripheral to manifest

### DIFF
--- a/ebmlite/schemata/mide_manifest.xml
+++ b/ebmlite/schemata/mide_manifest.xml
@@ -163,5 +163,11 @@
         <MasterElement name="DigitalPowerMAX77801" id="0x4DD1" mandatory="0" multiple="0" minver="1">Indicates the presence of a MAX77801 power management IC on the I2C1 bus.</MasterElement>
         <MasterElement name="DigitalLedThree" id="0x4DD2" mandatory="0" multiple="0" minver="1">Indicates that the membrane has a 3rd LED driven by the MCU.</MasterElement>
         <MasterElement name="DigitalSensorSI1133" id="0x4DD3" mandatory="0" multiple="0" minver="1">Indicates the presence of a SI1133 light sensor on the I2C1 bus.</MasterElement>
+        
+        <!-- Analog Out -->
+        <MasterElement name="PeriphHeater" id="0x4D90" mandatory="0" multiple="0" minver="1">Indicates the presence of an analog heater device.
+            <UIntegerElement name="PeriphHeaterPower" id="0x4D91" mandatory="0" multiple="0" minver="1">Output power of the heater in milliwats.</UIntegerElement>
+        </MasterElement>
+        
 </MasterElement>
 </Schema>

--- a/ebmlite/schemata/mide_manifest.xml
+++ b/ebmlite/schemata/mide_manifest.xml
@@ -165,9 +165,9 @@
         <MasterElement name="DigitalSensorSI1133" id="0x4DD3" mandatory="0" multiple="0" minver="1">Indicates the presence of a SI1133 light sensor on the I2C1 bus.</MasterElement>
         
         <!-- Analog Out -->
-        <MasterElement name="PeriphHeater" id="0x4D90" mandatory="0" multiple="0" minver="1">Indicates the presence of an analog heater device.
-            <UIntegerElement name="PeriphHeaterPower" id="0x4D91" mandatory="0" multiple="0" minver="1">Output power of the heater in milliwats.</UIntegerElement>
+        <MasterElement name="PeripheralHeater" id="0x4F00" mandatory="0" multiple="0" minver="1">Indicates the presence of an analog heater device.
+            <UIntegerElement name="PeripheralConfig" id="0x4F01" mandatory="0" multiple="0" minver="1">Configuration data for non-sensor peripherals. For the heater, it is the output power in milliwatts.</UIntegerElement>
         </MasterElement>
-        
+
 </MasterElement>
 </Schema>


### PR DESCRIPTION
New IDs 0x4D90 and 0x4D91
Note that I did not use SensorConfig for the power configuration of the heater just because the heater is not a sensor. I do not feel that strongly about it.
Ken, note that I change the `Power_dissipation_mW` item you had in your manifest to `PeriphHeaterPower`, so it would match the standard names

Closes #61 