### PR TITLE
Refactor `StringElement` parsing

### DIFF
--- a/ebmlite/core.py
+++ b/ebmlite/core.py
@@ -54,7 +54,7 @@ from xml.etree import ElementTree as ET
 
 from .decoding import readElementID, readElementSize
 from .decoding import readFloat, readInt, readUInt, readDate
-from .decoding import readUnicode
+from .decoding import readString, readUnicode
 from . import encoding
 from . import schemata
 
@@ -349,7 +349,7 @@ class StringElement(Element):
         """ Type-specific helper function for parsing the element's payload.
             It is assumed the file pointer is at the start of the payload.
         """
-        return readUnicode(stream, size)
+        return readString(stream, size)
 
     @classmethod
     def encodePayload(cls, data, length=None):

--- a/ebmlite/decoding.py
+++ b/ebmlite/decoding.py
@@ -187,11 +187,11 @@ def readString(stream, size):
         @return: The decoded value.
     """
     if size == 0:
-        return b''
+        return u''
 
     value = stream.read(size)
     value = value.partition(b'\x00')[0]
-    return value
+    return str(value, 'ascii')
 
 
 def readUnicode(stream, size):

--- a/ebmlite/decoding.py
+++ b/ebmlite/decoding.py
@@ -15,6 +15,7 @@ __all__ = ['readElementID', 'readElementSize', 'readFloat', 'readInt',
 
 from datetime import datetime, timedelta
 import struct
+import warnings
 
 # ==============================================================================
 #
@@ -191,7 +192,12 @@ def readString(stream, size):
 
     value = stream.read(size)
     value = value.partition(b'\x00')[0]
-    return str(value, 'ascii')
+
+    try:
+        return str(value, 'ascii')
+    except UnicodeDecodeError as ex:
+        warnings.warn(str(ex), UnicodeWarning)
+        return str(value, 'ascii', 'replace')
 
 
 def readUnicode(stream, size):

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -178,12 +178,12 @@ class testDecoding(unittest.TestCase):
         """ Test reading strings. """
         
         self.mockStream = BytesIO(b'')
-        self.assertEqual(readString(self.mockStream, 0), b'')
+        self.assertEqual(readString(self.mockStream, 0), u'')
         
         self.mockStream = BytesIO(b'test')
         mockLen = len(self.mockStream.getvalue())
         self.assertEqual(readString(self.mockStream, mockLen),
-                         b'test')
+                         u'test')
             
     
     


### PR DESCRIPTION
This is a follow-up to #51.

Specifically, this PR changes `StringElement` objects to parse using `readString`, and changing `readString` to return `str`'s instead of `bytes`'.

The main benefit in this change is that `StringElement` data will get parsed as an ASCII data stream (via `str(value, 'ascii')`) instead of a more generic UTF-8 data stream (via `str(value, 'utf8')`); this should better enforce the requirement that `StringElement`'s contain strictly ascii-encodable data, while still returning the data in the more user-friendly `str` data type.