### PR TITLE
Removing python versions that aren't officially supported.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 os: linux
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
@@ -17,16 +16,6 @@ after_success:
 
 matrix:
   include:
-    # This build is stalling after passing, not sure why.  Since python 3.5 is currently being tested, skip for now
-    # Windows doesn't support native python yet, so here we are - 3.5
-    # - os: windows
-    #   language: shell
-    #   env: PATH=/c/python35:/c/Python35/scripts:$PATH
-    #   before_install:
-    #     - choco install python3 --version=3.5.4
-    #     - python -m pip install virtualenv
-    #     - virtualenv $HOME/venv
-    #     - source $HOME/venv/Scripts/activate
     # Windows doesn't support native python yet, so here we are - 3.6
     - os: windows
       language: shell
@@ -54,7 +43,7 @@ matrix:
         - python -m pip install virtualenv
         - virtualenv $HOME/venv
         - source $HOME/venv/Scripts/activate
-    # Windows doesn't support native python yet, so here we are - 3.8
+    # Windows doesn't support native python yet, so here we are - 3.9
     - os: windows
       language: shell
       env: PATH=/c/python39:/c/Python39/scripts:$PATH
@@ -63,25 +52,4 @@ matrix:
         - python -m pip install virtualenv
         - virtualenv $HOME/venv
         - source $HOME/venv/Scripts/activate
-    # Windows doesn't support native python yet, so here we are - 3.9
-    - os: windows
-      language: shell
-      env:
-        - PATH=/c/python310:/c/Python310/scripts:$PATH
-        - ALLOW_FAILURES=TRUE
-      before_install:
-        - choco install python3 --pre
-        - python -m pip install virtualenv
-        - virtualenv $HOME/venv
-        - source $HOME/venv/Scripts/activate
-    - os: linux
-      language: python
-      python: "3.10-dev"
-      env: ALLOW_FAILURES=TRUE
-    - os: linux
-      language: python
-      python: "nightly"
-      env: ALLOW_FAILURES=TRUE
-  allow_failures:
-    - if: env(ALLOW_FAILURES)=TRUE
 


### PR DESCRIPTION
This deprecates python 3.5, and also removes python 3.10/dev from tests.  3.5 is past it's support life, and while seeing if things break in 3.10 is cool, the process of actually running the tests takes far too long.