### PR TITLE
Adding Codecov file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  range: 50..90
+ignore:
+  - "ebmlite/tools"


### PR DESCRIPTION
Adds a codecov.yml file to configure codecov.  This will reduce the threshold for "acceptable" coverage a bit, and ignore the tools directory in the package.