### PR TITLE
Explicitly cast to `int` before encoding integers

### DIFF
--- a/ebmlite/encoding.py
+++ b/ebmlite/encoding.py
@@ -13,6 +13,7 @@ __all__ = ['encodeBinary', 'encodeDate', 'encodeFloat', 'encodeId', 'encodeInt',
 
 import datetime
 import sys
+import warnings
 
 from .decoding import _struct_uint64, _struct_int64
 from .decoding import _struct_float32, _struct_float64
@@ -124,7 +125,11 @@ def encodeUInt(val, length=None):
             left-padded with ``0x00`` if `length` is not `None`.
         @raise ValueError: raised if val is longer than length.
     """
-    val = int(val)
+    if isinstance(val, float):
+        fval, val = val, int(val)
+        if fval != val:
+            warnings.warn('encodeUInt: float value {} encoded as {}'.format(fval, val))
+
     pad = b'\x00'
     packed = _struct_uint64.pack(val).lstrip(pad) or pad
 
@@ -147,7 +152,11 @@ def encodeInt(val, length=None):
             (for negative) if `length` is not `None`.
         @raise ValueError: raised if val is longer than length.
     """
-    val = int(val)
+    if isinstance(val, float):
+        fval, val = val, int(val)
+        if fval != val:
+            warnings.warn('encodeInt: float value {} encoded as {}'.format(fval, val))
+
     if val >= 0:
         pad = b'\x00'
         packed = _struct_int64.pack(val).lstrip(pad) or pad

--- a/ebmlite/encoding.py
+++ b/ebmlite/encoding.py
@@ -124,6 +124,7 @@ def encodeUInt(val, length=None):
             left-padded with ``0x00`` if `length` is not `None`.
         @raise ValueError: raised if val is longer than length.
     """
+    val = int(val)
     pad = b'\x00'
     packed = _struct_uint64.pack(val).lstrip(pad) or pad
 
@@ -146,6 +147,7 @@ def encodeInt(val, length=None):
             (for negative) if `length` is not `None`.
         @raise ValueError: raised if val is longer than length.
     """
+    val = int(val)
     if val >= 0:
         pad = b'\x00'
         packed = _struct_int64.pack(val).lstrip(pad) or pad

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# Testing
+pytest>=4.6
+codecov
+pytest-cov
+pytest-flake8
+pytest-console-scripts
+pytest-xdist[psutil]
+filelock


### PR DESCRIPTION
`encoding.encodeInt()` and `encodeUInt()` have been modified to cast to `int` before encoding.

Some old software refactored for Python 3 is suffering from Python 3's implicit casting of `int` to `float`. Python 2.7 allowed a `float` to be packed in a struct as an integer, but Python 3 raises `struct.error`. This fixes it.