### PR TITLE
v3.2.1

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     env:
       OS: ${{ matrix.os }}
@@ -31,7 +31,7 @@ jobs:
 
       - run: python -m pip install .[test]
 
-      - run: python -m pytest ./tests/ --cov=ebmlite --cov-report=xml
+      - run: python -m pytest ./tests/ --cov=ebmlite --cov-report=xml --flake8 -n auto
 
       - uses: codecov/codecov-action@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ TEST_REQUIRES = [
 
 setuptools.setup(
         name='ebmlite',
-        version='3.2.0',
+        version='3.2.1',
         author='Mide Technology',
         author_email='help@mide.com',
         description='A lightweight, "pure Python" library for parsing EBML (Extensible Binary Markup Language) data.',

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ TEST_REQUIRES = [
     'pytest-cov',
     'pytest-flake8',
     'pytest-console-scripts',
+    'pytest-xdist[psutil]',
     ]
 
 setuptools.setup(


### PR DESCRIPTION
`encodeInt()` and `encodeUInt()` now accept float values (which was allowed in Python 2.7), generates a warning if `x != int(x)`. Also created a `requirements.txt` with what's needed for development/testing.