### PR TITLE
ebml2xml change

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,17 +202,29 @@ Optional Argument *out*: A file-like stream to which to write.
 Optional argument *indent*: The string containing the character(s) used for each
         indentation.
 
-Utils can also be called from the command line with the following syntax:
+### Command Line Utilities
+When EBMLite is installed as a Python library, the Utils can be called from the command line. The commands available are:
 ```commandline
-python util.py {xml2ebml|ebml2xml|view} {FILE1.ebml|FILE1.xml} SCHEMA.xml [-o {FILE2.xml|FILE2.ebml}] [-c|--clobber] [-p|--pretty]
+python -m ebmlite.tools.ebml2xml
 ```
-The program requires you to specify a mode: xml2ebml, ebml2xml, or view.  The first two modes convert xml files to ebml files and ebml files to xml files, respectively; the last mode formats an IDE file to be human-readable.  
-FILE1: The location of the ebml or xml file to convert/view.  
-SCHEMA: The location of the schema to use when interpreting these files.  
-FILE2: The location to output to; otherwise, the output is directed into the console.  
--c|--clobber: If FILE2 exists, then overwrite it, otherwise the program will fail.  
--p|--pretty: Prints the output in a human-readable format.
-
+`ebml2xml` will translate an EBML file into XML. For example:
+```commandline
+python -m ebmlite.tools.ebml2xml DAQ11093_000001.ide mide_ide.xml -o DAQ11093_000001.xml
+```
+will translate `DAQ11093_000001.ide` into XML, and write the result into `DAQ11093_000001.xml`. The schema `mide_ide.xml` 
+is built in to the EBMLite library. 
+```commandline
+python -m ebmlite.tools.xml2ebml 
+```
+`xml2ebml` will translate EBML back in to XML. For example
+```commandline
+python -m ebmlite.tools.xml2ebml DAQ11093_000001.xml mide_ide.xml -o DAQ11093_000001b.ide
+```
+Will turn `DAQ11093_000001.xml` back into an IDE file.
+```commandline
+python -m ebmlite.tools.view_ebml
+```
+`view_ebml` will show summary element data about an EBML file, including element ID and type
 
 To Do
 =====

--- a/ebmlite/tools/ebml2xml.py
+++ b/ebmlite/tools/ebml2xml.py
@@ -29,27 +29,27 @@ def main():
         help="Clobber (overwrite) existing files.",
     )
     argparser.add_argument(
-        '-p', '--pretty', action="store_true", help="Generate 'pretty' XML.",
+        '-s', '--single', action="store_true", help="Generate XML as a single line with no newlines or indents",
     )
     argparser.add_argument(
-        '--min',
+        '-m', '--max',
         action="store_true",
-        help="Generate minimal XML with ebml2xml. Just element name and value",
+        help="Generate XML with maximum description, including offset, size, type, and id info",
     )
 
     args = argparser.parse_args()
 
-    with utils.load_files(args, binary_output=not args.pretty) as (schema, out):
+    with utils.load_files(args, binary_output=args.single) as (schema, out):
         doc = schema.load(args.input, headers=True)
-        if args.min:
+        if args.max:
+            root = ebmlite.util.toXml(doc, offsets=True, sizes=True, types=True, ids=True)
+        else:
             root = ebmlite.util.toXml(doc, offsets=False, sizes=False, types=False, ids=False)
-        else:
-            root = ebmlite.util.toXml(doc)  # , offsets, sizes, types, ids)
         s = ET.tostring(root, encoding="utf-8")
-        if args.pretty:
-            parseString(s).writexml(out, addindent='\t', newl='\n', encoding='utf-8')
-        else:
+        if args.single:
             out.write(s)
+        else:
+            parseString(s).writexml(out, addindent='\t', newl='\n', encoding='utf-8')
 
 
 if __name__ == "__main__":

--- a/ebmlite/tools/utils.py
+++ b/ebmlite/tools/utils.py
@@ -28,6 +28,6 @@ def load_files(args, binary_output=False):
 
     output = os.path.realpath(os.path.expanduser(args.output))
     if os.path.exists(output) and not args.clobber:
-        errPrint("Output file exists: %s" % args.output)
+        errPrint("Error: Output file already exists: %s" % args.output)
     with open(output, ('wb' if binary_output else 'w')) as out:
         yield (schema, out)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -23,6 +23,8 @@ def test_ebml2xml(script_runner):
         "--output",
         path_out,
         "--clobber",
+        "--max",
+        "--single"
     )
     assert result.success
 


### PR DESCRIPTION
Changed options in ebml2xml util to reflect standard use, and updated the documentation.
Making `--pretty` and `--min` options default to on, and adding the reverse `--single` and `--max`, for folks who want the output in a single line flooded with debug info.