### PR TITLE
Replaced `OrderedDict` with `dict` in Python 3.7+

### DIFF
--- a/ebmlite/core.py
+++ b/ebmlite/core.py
@@ -45,11 +45,11 @@ __all__ = ['BinaryElement', 'DateElement', 'Document', 'Element',
            'UnknownElement', 'VoidElement', 'loadSchema']
 
 from ast import literal_eval
-from collections import OrderedDict
 from datetime import datetime
 import errno
 import os.path
 from io import BytesIO, StringIO, IOBase
+import sys
 from xml.etree import ElementTree as ET
 
 from .decoding import readElementID, readElementSize
@@ -57,6 +57,13 @@ from .decoding import readFloat, readInt, readUInt, readDate
 from .decoding import readString, readUnicode
 from . import encoding
 from . import schemata
+
+# Dictionaries in Python 3.7+ are explicitly insert-ordered in all
+# implementations. If older, continue to use `collections.OrderedDict`.
+if sys.hexversion < 0x03070000:
+    from collections import OrderedDict
+else:
+    OrderedDict = dict
 
 # ==============================================================================
 #

--- a/ebmlite/core.py
+++ b/ebmlite/core.py
@@ -42,7 +42,7 @@ __credits__ = "David Randall Stokes, Connor Flanigan, Becker Awqatty, Derek Witt
 __all__ = ['BinaryElement', 'DateElement', 'Document', 'Element',
            'FloatElement', 'IntegerElement', 'MasterElement', 'Schema',
            'StringElement', 'UIntegerElement', 'UnicodeElement',
-           'UnknownElement', 'VoidElement', 'loadSchema']
+           'UnknownElement', 'VoidElement', 'loadSchema', 'parseSchema']
 
 from ast import literal_eval
 from datetime import datetime

--- a/ebmlite/core.py
+++ b/ebmlite/core.py
@@ -61,9 +61,9 @@ from . import schemata
 # Dictionaries in Python 3.7+ are explicitly insert-ordered in all
 # implementations. If older, continue to use `collections.OrderedDict`.
 if sys.hexversion < 0x03070000:
-    from collections import OrderedDict
+    from collections import OrderedDict as Dict
 else:
-    OrderedDict = dict
+    Dict = dict
 
 # ==============================================================================
 #
@@ -731,7 +731,7 @@ class MasterElement(Element):
                 very specific, and it isn't totally necessary for the core
                 library.
         """
-        result = OrderedDict()
+        result = Dict()
         for el in self:
             if el.multiple:
                 result.setdefault(el.name, []).append(el.dump())
@@ -934,7 +934,7 @@ class Document(MasterElement):
         if 'EBML' not in cls.schema:
             return {}
 
-        headers = OrderedDict()
+        headers = Dict()
         for elName, elType in (('EBMLVersion', int),
                                ('EBMLReadVersion', int),
                                ('DocType', str),
@@ -945,7 +945,7 @@ class Document(MasterElement):
                 if v is not None:
                     headers[elName] = v
 
-        return OrderedDict(EBML=headers)
+        return Dict(EBML=headers)
 
     @classmethod
     def encode(cls, stream, data, headers=False, **kwargs):


### PR DESCRIPTION
See #97 for a full explanation and rationale.

*tl;dr:* they should be somewhat more efficient and `repr()` better.