### PR TITLE
ES-768 Python version updates

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         exclude:
           - os: ubuntu-latest
             python-version: '3.6'

--- a/ebmlite/__init__.py
+++ b/ebmlite/__init__.py
@@ -2,3 +2,4 @@ from .core import *
 from .core import SCHEMA_PATH, SCHEMATA, __all__
 
 name = "ebmlite"
+__version__ = "3.3.1"

--- a/ebmlite/core.py
+++ b/ebmlite/core.py
@@ -48,6 +48,7 @@ from ast import literal_eval
 from datetime import datetime
 import errno
 import importlib
+import importlib.resources as importlib_resources
 from io import BytesIO, StringIO, IOBase
 import os.path
 from pathlib import Path
@@ -62,19 +63,6 @@ from .decoding import readString, readUnicode
 from . import encoding
 from . import schemata
 
-# Dictionaries in Python 3.7+ are explicitly insert-ordered in all
-# implementations. If older, continue to use `collections.OrderedDict`.
-if sys.hexversion < 0x03070000:
-    from collections import OrderedDict as Dict
-else:
-    Dict = dict
-
-# Additionally, `importlib.resources.files` is new to 3.9 as well; this is
-# part of a work-around.
-if sys.hexversion < 0x03090000:
-    importlib_resources = None
-else:
-    import importlib.resources as importlib_resources
 
 # ==============================================================================
 #
@@ -745,7 +733,7 @@ class MasterElement(Element):
                 very specific, and it isn't totally necessary for the core
                 library.
         """
-        result = Dict()
+        result = {}
         for el in self:
             if el.multiple:
                 result.setdefault(el.name, []).append(el.dump())
@@ -948,7 +936,7 @@ class Document(MasterElement):
         if 'EBML' not in cls.schema:
             return {}
 
-        headers = Dict()
+        headers = {}
         for elName, elType in (('EBMLVersion', int),
                                ('EBMLReadVersion', int),
                                ('DocType', str),
@@ -959,7 +947,7 @@ class Document(MasterElement):
                 if v is not None:
                     headers[elName] = v
 
-        return Dict(EBML=headers)
+        return dict(EBML=headers)
 
     @classmethod
     def encode(cls, stream, data, headers=False, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,27 @@
+import codecs
+import os.path
 import setuptools
+
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
 
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 INSTALL_REQUIRES = [
-#    'numpy',
     ]
 
 TEST_REQUIRES = [
@@ -21,7 +37,7 @@ TEST_REQUIRES = [
 
 setuptools.setup(
         name='ebmlite',
-        version='3.3.1',
+        version=get_version('ebmlite/__init__.py'),
         author='Mide Technology',
         author_email='help@mide.com',
         description='A lightweight, "pure Python" library for parsing EBML (Extensible Binary Markup Language) data.',
@@ -32,12 +48,11 @@ setuptools.setup(
         classifiers=['Development Status :: 5 - Production/Stable',
                      'License :: OSI Approved :: MIT License',
                      'Natural Language :: English',
-                     'Programming Language :: Python :: 3.6',
-                     'Programming Language :: Python :: 3.7',
-                     'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: 3.9',
                      'Programming Language :: Python :: 3.10',
                      'Programming Language :: Python :: 3.11',
+                     'Programming Language :: Python :: 3.12',
+                     'Programming Language :: Python :: 3.13',
                      ],
         keywords='ebml binary matroska webm',
         packages=setuptools.find_packages(exclude="tests"),


### PR DESCRIPTION
* Updated Python versions in setup and unit tests, removed < 3.9, added 3.12 and 3.13
* Removed special-casing for Python<3.9
* setup reads `__version__ ` from `__init__.py` (same pattern we use in other packages)