### PR TITLE
Adding a -n option to skip the standard EBML header when using tools.xml2ebml

### DIFF
--- a/ebmlite/tools/xml2ebml.py
+++ b/ebmlite/tools/xml2ebml.py
@@ -26,10 +26,14 @@ def main():
         '-c', '--clobber', action="store_true",
         help="Clobber (overwrite) existing files.",
     )
+    argparser.add_argument(
+        '-n', '--no_header', action="store_false",
+        help="Do not write the standard EBML header segment.",
+    )
     args = argparser.parse_args()
 
     with utils.load_files(args, binary_output=True) as (schema, out):
-        ebmlite.util.xml2ebml(args.input, out, schema)  # , sizeLength=4, headers=True, unknown=True)
+        ebmlite.util.xml2ebml(args.input, out, schema, headers=args.no_header)  # , sizeLength=4, headers=True, unknown=True)
 
 
 if __name__ == "__main__":

--- a/ebmlite/tools/xml2ebml.py
+++ b/ebmlite/tools/xml2ebml.py
@@ -27,13 +27,14 @@ def main():
         help="Clobber (overwrite) existing files.",
     )
     argparser.add_argument(
-        '-n', '--no_header', action="store_false",
+        '-n', '--no_header', action="store_true",
         help="Do not write the standard EBML header segment.",
     )
     args = argparser.parse_args()
 
+    header = not args.no_header     # Removing some naming confusion, if no_header=false, header argument should be true
     with utils.load_files(args, binary_output=True) as (schema, out):
-        ebmlite.util.xml2ebml(args.input, out, schema, headers=args.no_header)  # , sizeLength=4, headers=True, unknown=True)
+        ebmlite.util.xml2ebml(args.input, out, schema, headers=header)  # , sizeLength=4, headers=True, unknown=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Simple stuff, but it would help for some config file generation I'm doing right now